### PR TITLE
Added env variable BOUWDOSSIERS_OBJECTSTORE_CONTAINER to allow changing

### DIFF
--- a/src/stadsarchief/objectstore.py
+++ b/src/stadsarchief/objectstore.py
@@ -4,7 +4,7 @@ import logging
 from calendar import timegm
 from typing import List, Tuple
 from objectstore import objectstore, get_full_container_list
-from stadsarchief.settings import OBJECTSTORE, DATA_DIR
+from stadsarchief.settings import OBJECTSTORE, DATA_DIR, BOUWDOSSIERS_OBJECTSTORE_CONTAINER
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ def get_objectstore_connection():
 
 def get_all_files():
     connection = get_objectstore_connection()
-    container_name = 'dossiers'
+    container_name = BOUWDOSSIERS_OBJECTSTORE_CONTAINER
     os.makedirs(DATA_DIR, exist_ok=True)
     documents_meta = get_full_container_list(connection, container_name)
     for meta in documents_meta:

--- a/src/stadsarchief/settings.py
+++ b/src/stadsarchief/settings.py
@@ -63,6 +63,10 @@ OBJECTSTORE = dict(
     REGION_NAME='NL',
 )
 
+BOUWDOSSIERS_OBJECTSTORE_CONTAINER = os.getenv(
+    'BOUWDOSSIERS_OBJECTSTORE_CONTAINER', 'dossiers_acceptance'
+)
+
 PROJECT_DIR = os.path.abspath(os.path.join(BASE_DIR, '..'))
 DATA_DIR = '/tmp/bouwdossiers'
 


### PR DESCRIPTION
the container name when deploying the project to acceptance. Now
acceptance should have test data instead of production data.